### PR TITLE
add link to the Slack signup page

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
 				<br> <br> Join us on Telegram at <a class="whitelink" href="https://telegram.me/BTCFork">@BTCFork</a>
 				<br> <br> Follow us on Twitter at <a class="whitelink" href="https://twitter.com/btcfork">@btcfork</a>
 				<br> <br> Help to translate this site at <a class="whitelink" href="https://www.transifex.com/bitcoinforksorg/bitcoinforksorg-website/">www.transifex.com</a>
-				<br> <br> Join our development Slack (coming soon)
+				<br> <br> Join our development Slack <a class="whitelink" href="https://btcforks.signup.team/">here</a>
 				</p>
 			</div> <!-- end sixteen columns -->	
 	


### PR DESCRIPTION
simplest link text I could think of which will make it easy to translate to other languages (the signup page is English only though - can't easily change that I guess)
