### PR TITLE
Hotfix/fix cc0 link

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,10 +194,10 @@
 					<img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0">
 				</a>
 				<br>
-				To the extent possible under law,
-				<a rel="dct:publisher" href="https://bitcoinforks.org">bitcoinforks.org</a>
-				has waived all copyright and related or neighboring rights to
-				<span property="dct:title">bitcoinforks.org</span>
+				To the extent possible under law, the
+				<a rel="dct:publisher" href="https://bitcoinforks.org">BTC Fork team</a>
+				has waived all copyright and related or neighboring rights to the content on this site, 
+				<span property="dct:title">bitcoinforks.org</span>.
 				This work is published from:
 				<span property="vcard:Country" datatype="dct:ISO3166" content="US" about="bitcoinforks.org">
 					United States

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
 				</a>
 				<br>
 				To the extent possible under law,
-				<a rel="dct:publisher" href="bitcoinforks.org">bitcoinforks.org</a>
+				<a rel="dct:publisher" href="https://bitcoinforks.org">bitcoinforks.org</a>
 				has waived all copyright and related or neighboring rights to
 				<span property="dct:title">bitcoinforks.org</span>
 				This work is published from:


### PR DESCRIPTION
An attempt to improve the CC waiver blurb by fixing the broken link and changing publisher to 'BTC Fork team' and trying to improve the structure of the sentence.
