### PR TITLE
change Bitcoin whitepaper to censorship-opposing site

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -159,7 +159,7 @@
 					</a>
           </p>
           <p class="largebody italics">
-            <a href="https://bitcoin.org/bitcoin.pdf" class="nounderlinelink">
+            <a href="https://bitcoin.com/bitcoin.pdf" class="nounderlinelink">
 						"<span id="vision-satoshi-quote-whitepaper-conclusion" class="contenteditable">Knoten können das Netzwerk jederzeit verlassen oder sich anschliessen, indem sie Proof-of-Work als Beweis dessen akzeptieren, was in ihrer Abwesenheit geschehen ist. Sie wählen mit ihrer Rechenkraft, drücken ihre Akzeptanz von gültigen Blöcken dadurch aus dass sie auf ihnen weiterrechnen und verwerfen ungültige Blöcke dadurch, dass sie sich weigern auf ihnen zu bauen. <b>Alle benötigten Regeln und Anreize können durch diesen Konsensmechanismus erzwungen werden.</b></span>"
 						<br>– <span data-translation="s-nakamoto">S. Nakamoto</span><span id="vision-satoshi-quote-whitepaper-conclusion-text" class="contenteditable">, Bitcoin Whitepaper, Schlusskapitel</span>
 					</a>
@@ -178,7 +178,7 @@
           </p>
           <br>
           <div class="vision" style="padding-bottom: 0px; text-align: center;">
-            <a href="https://bitcoin.org/bitcoin.pdf">
+            <a href="https://bitcoin.com/bitcoin.pdf">
               <div class="button">
                 <span id="vision-button-read-the-whitepaper" class="contenteditable">LESE DAS WHITEPAPER</span>
               </div>

--- a/en/index.html
+++ b/en/index.html
@@ -159,7 +159,7 @@
 					</a>
           </p>
           <p class="largebody italics">
-            <a href="https://bitcoin.org/bitcoin.pdf" class="nounderlinelink">
+            <a href="https://bitcoin.com/bitcoin.pdf" class="nounderlinelink">
 						"<span id="vision-satoshi-quote-whitepaper-conclusion" class="contenteditable">Nodes can leave and rejoin the network at will, accepting the proof-of-work chain as proof of what happened while they were gone. They vote with their CPU power, expressing their acceptance of valid blocks by working on extending them and rejecting invalid blocks by refusing to work on them. <b>Any needed rules and incentives can be enforced with this consensus mechanism.</b></span>"
 						<br>– <span data-translation="s-nakamoto">S. Nakamoto</span><span id="vision-satoshi-quote-whitepaper-conclusion-text" class="contenteditable">, Bitcoin whitepaper conclusion</span>
 					</a>
@@ -178,7 +178,7 @@
           </p>
           <br>
           <div class="vision" style="padding-bottom: 0px; text-align: center;">
-            <a href="https://bitcoin.org/bitcoin.pdf">
+            <a href="https://bitcoin.com/bitcoin.pdf">
               <div class="button">
                 <span id="vision-button-read-the-whitepaper" class="contenteditable">Read the Whitepaper</span>
               </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -159,7 +159,7 @@
 					</a>
           </p>
           <p class="largebody italics">
-            <a href="https://bitcoin.org/bitcoin.pdf" class="nounderlinelink">
+            <a href="https://bitcoin.com/bitcoin.pdf" class="nounderlinelink">
 						"<span id="vision-satoshi-quote-whitepaper-conclusion" class="contenteditable">Les nœuds peuvent quitter et rejoindre le réseau à volonté, en acceptant la chaîne de preuve de travail comme preuve des événements passés pendant qu'ils étaient partis. Ils votent avec la puissance de calcul de leurs processeurs, exprimant ainsi leur acceptation des blocs valides en travaillant sur les blocs qui les prolongent et en rejetant les blocs invalides en refusant de travailler dessus. <b>Toutes les règles et mécanismes incitateurs nécessaires peuvent être mis en oeuvre grâce à ce mécanisme de consensus</b>.</span>"
 						<br>– <span data-translation="s-nakamoto">S. Nakamoto</span><span id="vision-satoshi-quote-whitepaper-conclusion-text" class="contenteditable">, Conclusion du Bitcoin Whitepaper</span>
 					</a>
@@ -178,7 +178,7 @@
           </p>
           <br>
           <div class="vision" style="padding-bottom: 0px; text-align: center;">
-            <a href="https://bitcoin.org/bitcoin.pdf">
+            <a href="https://bitcoin.com/bitcoin.pdf">
               <div class="button">
                 <span id="vision-button-read-the-whitepaper" class="contenteditable">LIRE LE WHITEPAPER</span>
               </div>

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
 					</a>
           </p>
           <p class="largebody italics">
-            <a href="https://bitcoin.org/bitcoin.pdf" class="nounderlinelink">
+            <a href="https://bitcoin.com/bitcoin.pdf" class="nounderlinelink">
 						"<span id="vision-satoshi-quote-whitepaper-conclusion" class="contenteditable">Nodes can leave and rejoin the network at will, accepting the proof-of-work chain as proof of what happened while they were gone. They vote with their CPU power, expressing their acceptance of valid blocks by working on extending them and rejecting invalid blocks by refusing to work on them. <b>Any needed rules and incentives can be enforced with this consensus mechanism.</b></span>"
 						<br>– <span data-translation="s-nakamoto">S. Nakamoto</span><span id="vision-satoshi-quote-whitepaper-conclusion-text" class="contenteditable">, Bitcoin whitepaper conclusion</span>
 					</a>
@@ -178,7 +178,7 @@
           </p>
           <br>
           <div class="vision" style="padding-bottom: 0px; text-align: center;">
-            <a href="https://bitcoin.org/bitcoin.pdf">
+            <a href="https://bitcoin.com/bitcoin.pdf">
               <div class="button">
                 <span id="vision-button-read-the-whitepaper" class="contenteditable">Read the Whitepaper</span>
               </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -159,7 +159,7 @@
 					</a>
           </p>
           <p class="largebody italics">
-            <a href="https://bitcoin.org/bitcoin.pdf" class="nounderlinelink">
+            <a href="https://bitcoin.com/bitcoin.pdf" class="nounderlinelink">
 						"<span id="vision-satoshi-quote-whitepaper-conclusion" class="contenteditable">节点可以随时随意的离开或加入比特币的网络，通过工作量证明链（proof-of-work chain）来验证离开网络之后所发生的交易。它们以处理器能力投票，通过延伸有效区块来表示接受该区块、或通过不延伸无效区块来表示拒绝该区块。 <b>一切所需的规则与激励可以用以上的共识机制来实现。</b></span>"
 						<br>– <span data-translation="s-nakamoto">中本聪</span><span id="vision-satoshi-quote-whitepaper-conclusion-text" class="contenteditable">，比特币白皮书的总结</span>
 					</a>
@@ -178,7 +178,7 @@
           </p>
           <br>
           <div class="vision" style="padding-bottom: 0px; text-align: center;">
-            <a href="https://bitcoin.org/bitcoin.pdf">
+            <a href="https://bitcoin.com/bitcoin.pdf">
               <div class="button">
                 <span id="vision-button-read-the-whitepaper" class="contenteditable">阅读白皮书</span>
               </div>


### PR DESCRIPTION
Changed to use https://bitcoin.com/bitcoin.pdf instead.
Thanks to the Redditor who pointed out to me that the link to bitcoin.org promotes that site, which is run by folks who have resorted to censorship on forums they run.
That is certainly not something that BTCfork wants to implicitly endorse.